### PR TITLE
frt-13 -- switchable sentiment analysis between

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4860,6 +4860,14 @@
                 }
             }
         },
+        "node_modules/@remix-run/router": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+            "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.17.2",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.17.2.tgz",
@@ -15591,6 +15599,36 @@
                 }
             }
         },
+        "node_modules/react-router": {
+            "version": "6.23.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+            "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+            "dependencies": {
+                "@remix-run/router": "1.16.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
+            }
+        },
+        "node_modules/react-router-dom": {
+            "version": "6.23.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+            "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+            "dependencies": {
+                "@remix-run/router": "1.16.1",
+                "react-router": "6.23.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
+            }
+        },
         "node_modules/react-smooth": {
             "version": "4.0.1",
             "license": "MIT",
@@ -18208,6 +18246,7 @@
                 "prettier-plugin-tailwindcss": "^0.5.14",
                 "react": "^18.3.1",
                 "react-dom": "^18.2.0",
+                "react-router-dom": "^6.23.1",
                 "recharts": "^2.12.7",
                 "tailwindcss-radix": "^3.0.3",
                 "tinyspy": "^2.2.1"

--- a/web/package.json
+++ b/web/package.json
@@ -38,6 +38,7 @@
 		"prettier-plugin-tailwindcss": "^0.5.14",
 		"react": "^18.3.1",
 		"react-dom": "^18.2.0",
+		"react-router-dom": "^6.23.1",
 		"recharts": "^2.12.7",
 		"tailwindcss-radix": "^3.0.3",
 		"tinyspy": "^2.2.1"

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,16 +1,11 @@
-import Tabs from '../components/charts/ChartTabNav';
-import { TEST_DATA } from '../components/charts/testdata';
-import ReviewsInput from '../components/reviews/ReviewsInput';
-import ShowList from './Showlist';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-import SentimentAnalysis from './Showlist';
+import { BrowserRouter as Router } from 'react-router-dom';
 
+import ShowList from './Showlist';
 
 export default function Home() {
 	return (
 		<Router>
-      <ShowList streamingservice="Paramount+"/>
-    </Router>
-		
+			<ShowList streamingservice="Paramount+" />
+		</Router>
 	);
 }

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,16 +1,16 @@
 import Tabs from '../components/charts/ChartTabNav';
 import { TEST_DATA } from '../components/charts/testdata';
 import ReviewsInput from '../components/reviews/ReviewsInput';
+import ShowList from './Showlist';
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import SentimentAnalysis from './Showlist';
+
 
 export default function Home() {
 	return (
-		<div className="flex h-screen flex-row items-center justify-center bg-[#132a3a]">
-			<div className="mr-20 mt-10">
-				<ReviewsInput />
-			</div>
-			<div className="mt-10">
-				<Tabs data={TEST_DATA}></Tabs>
-			</div>
-		</div>
+		<Router>
+      <ShowList streamingservice="Paramount+"/>
+    </Router>
+		
 	);
 }

--- a/web/src/pages/SentimentAnalysis.tsx
+++ b/web/src/pages/SentimentAnalysis.tsx
@@ -1,35 +1,36 @@
 import React from 'react';
+
 import Tabs from '../components/charts/ChartTabNav';
 import ReviewsInput from '../components/reviews/ReviewsInput';
 
 interface DataPoint {
-  name: string;
-  number: number;
+	name: string;
+	number: number;
 }
 
 interface SentimentAnalysisProps {
-  showName: string | null;
-  data: DataPoint[] | null;
+	showName: string | null;
+	data: DataPoint[] | null;
 }
 
 export default function SentimentAnalysis({ showName, data }: SentimentAnalysisProps) {
-  if (!showName || !data) {
-    return (
-      <div className="flex h-full items-center justify-center text-white">
-        <p>Select a show to view its sentiment analysis.</p>
-      </div>
-    );
-  }
+	if (!showName || !data) {
+		return (
+			<div className="flex h-full items-center justify-center text-white">
+				<p>Select a show to view its sentiment analysis.</p>
+			</div>
+		);
+	}
 
-  return (
-    <div className="flex h-full flex-col items-center justify-center">
-      <h1 className="mb-8 text-3xl font-bold text-white">{showName}</h1>
-      <div className="mb-8">
-        <Tabs data={data}></Tabs>
-      </div>
-      <div>
-        <ReviewsInput />
-      </div>
-    </div>
-  );
+	return (
+		<div className="flex h-full flex-col items-center justify-center">
+			<h1 className="mb-8 text-3xl font-bold text-white">{showName}</h1>
+			<div className="mb-8">
+				<Tabs data={data}></Tabs>
+			</div>
+			<div>
+				<ReviewsInput />
+			</div>
+		</div>
+	);
 }

--- a/web/src/pages/SentimentAnalysis.tsx
+++ b/web/src/pages/SentimentAnalysis.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Tabs from '../components/charts/ChartTabNav';
+import ReviewsInput from '../components/reviews/ReviewsInput';
+
+interface DataPoint {
+  name: string;
+  number: number;
+}
+
+interface SentimentAnalysisProps {
+  showName: string | null;
+  data: DataPoint[] | null;
+}
+
+export default function SentimentAnalysis({ showName, data }: SentimentAnalysisProps) {
+  if (!showName || !data) {
+    return (
+      <div className="flex h-full items-center justify-center text-white">
+        <p>Select a show to view its sentiment analysis.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center">
+      <h1 className="mb-8 text-3xl font-bold text-white">{showName}</h1>
+      <div className="mb-8">
+        <Tabs data={data}></Tabs>
+      </div>
+      <div>
+        <ReviewsInput />
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Showlist.tsx
+++ b/web/src/pages/Showlist.tsx
@@ -1,62 +1,63 @@
 import React, { useState } from 'react';
-import SentimentAnalysis from './SentimentAnalysis';
+
 import { TEST_DATA } from '../components/charts/testdata';
+import SentimentAnalysis from './SentimentAnalysis';
 
 interface DataPoint {
-  name: string;
-  number: number;
+	name: string;
+	number: number;
 }
 
-
 interface Show {
-  name: string;
-  data: DataPoint[];
+	name: string;
+	data: DataPoint[];
 }
 
 const shows: Show[] = [
-  { name: 'Yellowjackets', data: TEST_DATA },
-  { name: 'Shogun', data: TEST_DATA },
-  { name: 'Criminal Minds', data: TEST_DATA },
-  { name: 'Big Brother', data: TEST_DATA },
-  { name: 'Halo', data: TEST_DATA },
+	{ name: 'Yellowjackets', data: TEST_DATA },
+	{ name: 'Shogun', data: TEST_DATA },
+	{ name: 'Criminal Minds', data: TEST_DATA },
+	{ name: 'Big Brother', data: TEST_DATA },
+	{ name: 'Halo', data: TEST_DATA },
 ];
 
-export default function ShowList( { streamingservice }: {streamingservice: string} ) {
-  const [selectedShow, setSelectedShow] = useState<Show | null>(null);
+export default function ShowList({ streamingservice }: { streamingservice: string }) {
+	const [selectedShow, setSelectedShow] = useState<Show | null>(null);
 
-  const handleShowClick = (show: Show) => {
-    setSelectedShow(show);
-  };
+	const handleShowClick = (show: Show) => {
+		setSelectedShow(show);
+	};
 
-  return (
-    <div className="flex min-h-screen bg-[#132a3a]">
-      <div className="w-1/3 p-8">
-        <h1 className="mb-8 text-3xl font-bold text-white">{streamingservice}</h1>
-        <ul className="space-y-4">
-          {shows.map((show) => (
-            <li
-              key={show.name}
-              className={`cursor-pointer rounded-lg px-4 py-2 text-xl text-white ${
-                selectedShow?.name === show.name
-                  ? 'bg-[#10d48e]'
-                  : 'bg-[#204a5e] hover:bg-[#2a6a83]'
-              }`}
-              onClick={() => handleShowClick(show)}
-            >
-              {show.name}
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div className="w-2/3 p-8">
-        {selectedShow ? (
-          <SentimentAnalysis showName={selectedShow.name} data={selectedShow.data} />
-        ) : (
-          <div className="flex items-center justify-center text-white">
-            <p>Select a show to view its sentiment analysis.</p>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+	return (
+		<div className="flex min-h-screen bg-[#132a3a]">
+			<div className="w-1/3 p-8">
+				<h1 className="mb-8 text-3xl font-bold text-white">{streamingservice}</h1>
+				<ul className="space-y-4">
+					{shows.map((show) => (
+						<li key={show.name} className="rounded-lg">
+							<button
+								className={`w-full cursor-pointer rounded-lg px-4 py-2 text-left text-xl text-white ${
+									selectedShow?.name === show.name
+										? 'bg-[#10d48e]'
+										: 'bg-[#204a5e] hover:bg-[#2a6a83]'
+								}`}
+								onClick={() => handleShowClick(show)}
+							>
+								{show.name}
+							</button>
+						</li>
+					))}
+				</ul>
+			</div>
+			<div className="w-2/3 p-8">
+				{selectedShow ? (
+					<SentimentAnalysis showName={selectedShow.name} data={selectedShow.data} />
+				) : (
+					<div className="flex items-center justify-center text-white">
+						<p>Select a show to view its sentiment analysis.</p>
+					</div>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/web/src/pages/Showlist.tsx
+++ b/web/src/pages/Showlist.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import SentimentAnalysis from './SentimentAnalysis';
+import { TEST_DATA } from '../components/charts/testdata';
+
+interface DataPoint {
+  name: string;
+  number: number;
+}
+
+
+interface Show {
+  name: string;
+  data: DataPoint[];
+}
+
+const shows: Show[] = [
+  { name: 'Yellowjackets', data: TEST_DATA },
+  { name: 'Shogun', data: TEST_DATA },
+  { name: 'Criminal Minds', data: TEST_DATA },
+  { name: 'Big Brother', data: TEST_DATA },
+  { name: 'Halo', data: TEST_DATA },
+];
+
+export default function ShowList( { streamingservice }: {streamingservice: string} ) {
+  const [selectedShow, setSelectedShow] = useState<Show | null>(null);
+
+  const handleShowClick = (show: Show) => {
+    setSelectedShow(show);
+  };
+
+  return (
+    <div className="flex min-h-screen bg-[#132a3a]">
+      <div className="w-1/3 p-8">
+        <h1 className="mb-8 text-3xl font-bold text-white">{streamingservice}</h1>
+        <ul className="space-y-4">
+          {shows.map((show) => (
+            <li
+              key={show.name}
+              className={`cursor-pointer rounded-lg px-4 py-2 text-xl text-white ${
+                selectedShow?.name === show.name
+                  ? 'bg-[#10d48e]'
+                  : 'bg-[#204a5e] hover:bg-[#2a6a83]'
+              }`}
+              onClick={() => handleShowClick(show)}
+            >
+              {show.name}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="w-2/3 p-8">
+        {selectedShow ? (
+          <SentimentAnalysis showName={selectedShow.name} data={selectedShow.data} />
+        ) : (
+          <div className="flex items-center justify-center text-white">
+            <p>Select a show to view its sentiment analysis.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
shows

### Description

Added Showlist and SentimentAnalysis components with hardcoded data that toggles between different shows within a given streaming service. Changed home.tsx to display the showlist component. Data is hardcoded within showlist component but may want to modify it so we can pass in the data of 5 shows by way of a prop.

### QA

Should be able to see the changes just by running on your local, home.tsx has been changed to address the issue
### Packages

Please describe any additional packages you added to package.json
-- added react-router-dom

### Linear Issue Tracking

Fixes FRT-13

### Checklist

- [ ] Code compiles correctly
- [ ] Added comments
- [ ] Ran linter and made sure there were no errors
- [ ] Double checked [wiki naming conventions](https://github.com/NU394-S2024TTh/tribe-a/wiki/Development-Practices#naming-conventions)
- [ ] Extended the README / documentation, if necessary
